### PR TITLE
Feat create user controller

### DIFF
--- a/authUser/src/main/java/com/ead/authuser/controllers/UserController.java
+++ b/authUser/src/main/java/com/ead/authuser/controllers/UserController.java
@@ -1,0 +1,49 @@
+package com.ead.authuser.controllers;
+
+import com.ead.authuser.models.UserModel;
+import com.ead.authuser.services.UserService;
+import jakarta.websocket.server.PathParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@RestController
+@CrossOrigin(origins = "*", maxAge = 3600)
+@RequestMapping("/users")
+public class UserController {
+
+    @Autowired
+    UserService userService;
+
+    @GetMapping("/")
+    public ResponseEntity<List<UserModel>> getAllUsers(){
+        return ResponseEntity.status(HttpStatus.OK).body(userService.findAll());
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<Object> getOneUser(@PathVariable(value = "userId")UUID userId){
+        Optional<UserModel> userModelOptional = userService.findById(userId);
+        if(!userModelOptional.isPresent()){
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("User not found!");
+        } else {
+            return ResponseEntity.status(HttpStatus.OK).body(userModelOptional.get());
+        }
+    }
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<Object> deleteUser(@PathVariable(value = "userId")UUID userId){
+        Optional<UserModel> userModelOptional = userService.findById(userId);
+        if(!userModelOptional.isPresent()){
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("User not found!");
+        } else {
+            userService.delete(userModelOptional.get());
+            return ResponseEntity.status(HttpStatus.OK).body("User deleted successfully!");
+        }
+    }
+}
+

--- a/authUser/src/main/java/com/ead/authuser/services/UserService.java
+++ b/authUser/src/main/java/com/ead/authuser/services/UserService.java
@@ -1,7 +1,17 @@
 package com.ead.authuser.services;
 
+import com.ead.authuser.models.UserModel;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @Service
 public interface UserService {
+    List<UserModel> findAll();
+
+    Optional<UserModel> findById(UUID userId);
+
+    void delete(UserModel userModel);
 }

--- a/authUser/src/main/java/com/ead/authuser/services/impl/UserServiceImpl.java
+++ b/authUser/src/main/java/com/ead/authuser/services/impl/UserServiceImpl.java
@@ -1,11 +1,31 @@
 package com.ead.authuser.services.impl;
 
+import com.ead.authuser.models.UserModel;
 import com.ead.authuser.repositories.UserRepository;
 import com.ead.authuser.services.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public class UserServiceImpl implements UserService {
 
     @Autowired
     UserRepository userRepository;
+
+    @Override
+    public List<UserModel> findAll() {
+        return userRepository.findAll();
+    }
+
+    @Override
+    public Optional<UserModel> findById(UUID userId) {
+        return userRepository.findById(userId);
+    }
+
+    @Override
+    public void delete(UserModel userModel) {
+        userRepository.delete(userModel);
+    }
 }


### PR DESCRIPTION
Este PR adiciona a implementação inicial do UserController, responsável por gerenciar operações relacionadas aos usuários. Foram criadas as seguintes rotas:

Endpoints Implementados

- GET /users – Buscar todos os usuários

- GET /users/{id} – Buscar um usuário pelo ID

- DELETE /users/{id} – Deletar um usuário pelo ID

Observações

- A estrutura básica do controller e das rotas foi definida.

- A integração com as camadas de serviço/repositório está assumida como funcional.